### PR TITLE
Add compere_to_ref metrics calculation.

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -10,3 +10,4 @@ product_yamls:
   deepbgc_product_mapping: "deepbgc_class_mapping.yaml"
 
 bgc_completeness_margin: 100
+allowed_gap_for_fragmented_recovery: 100

--- a/configs/report_config.yaml
+++ b/configs/report_config.yaml
@@ -13,7 +13,8 @@ basic_report:
   grouping_dimensions:
     product_type:
       include_total: true
-      order: ["total", "NRPS", "PKS", "RiPP", "Terpene", "Saccharide", "Alkaloid", "Hybrid"]
+      order: ["total", "NRPS", "PKS", "RiPP", "Terpene", "Saccharide", "Alkaloid",
+       "Hybrid"]
     completeness:
       include_total: true
       order: ["total", "Complete", "Incomplete", "Unknown"]
@@ -23,32 +24,33 @@ basic_report:
 
 compare_to_reference:
   metrics:
-    - name: "fully_recovered_bgcs"
+    - name: "fully_recovered_bgcs_count"
       display_name: "Fully recovered BGCs"
-      description: "Reference BGCs where >95% of the region is covered by at least one assembly BGC with the same product type"
-    - name: "partially_recovered_bgcs"
+      description: "Reference BGCs where >95% of the region is covered by at least one
+       assembly BGC with the same product type"
+    - name: "partially_recovered_bgcs_count"
       display_name: "Partially recovered BGCs"
-      description: "Reference BGCs where 10-95% of the region is covered by assembly BGCs"
-    - name: "missed_bgcs"
+      description: "Reference BGCs where 10-95% of the region is covered by assembly
+       BGCs"
+    - name: "missed_bgcs_count"
       display_name: "Missed BGCs"
       description: "Reference BGCs with <10% coverage by any assembly BGC"
-    - name: "fragmented_recovery"
-      display_name: "Fragmented recovery"
+    - name: "fragmented_recovery_count"
+      display_name: "Fragmented BGCs"
       description: "Reference BGCs recovered by multiple disjoint assembly BGCs"
-    - name: "misclassified_product_type"
+    - name: "misclassified_product_type_count"
       display_name: "Misclassified product type"
-      description: "Recovered reference BGCs predicted with a wrong product type in the assembly"
+      description: "Recovered reference BGCs predicted with a wrong product type in
+       the assembly"
     - name: "recovery_rate"
       display_name: "Recovery rate"
       description: "Percentage of reference BGCs that are fully or partially recovered"
-    - name: "mean_coverage"
-      display_name: "Mean coverage"
-      description: "Average coverage of reference BGCs by assembly BGCs"
-      
+    
   grouping_dimensions:
     product_type:
       include_total: true
-      order: ["total", "NRPS", "PKS", "RiPP", "Terpene", "Saccharide", "Alkaloid", "Hybrid"]
+      order: ["total", "NRPS", "PKS", "RiPP", "Terpene", "Saccharide", "Alkaloid",
+       "Hybrid"]
     completeness:
       include_total: true
       order: ["total", "Complete", "Incomplete", "Unknown"]
@@ -77,7 +79,8 @@ compare_tools:
   grouping_dimensions:
     product_type:
       include_total: true
-      order: ["total", "NRPS", "PKS", "RiPP", "Terpene", "Saccharide", "Alkaloid", "Hybrid"]
+      order: ["total", "NRPS", "PKS", "RiPP", "Terpene", "Saccharide", "Alkaloid",
+       "Hybrid"]
     tool:
       include_total: false
       order: ["antiSMASH", "GECCO", "DeepBGC", "BiG-SCAPE"]
@@ -107,7 +110,8 @@ compare_samples:
   grouping_dimensions:
     product_type:
       include_total: true
-      order: ["total", "NRPS", "PKS", "RiPP", "Terpene", "Saccharide", "Alkaloid", "Hybrid"]
+      order: ["total", "NRPS", "PKS", "RiPP", "Terpene", "Saccharide", "Alkaloid",
+       "Hybrid"]
     sample_group:
       include_total: true
       order: ["total", "group_A", "group_B", "group_C"]

--- a/src/compare_to_ref_data.py
+++ b/src/compare_to_ref_data.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Optional
 
 from src.genome_mining_result import Bgc
 
@@ -25,9 +26,9 @@ class Intersection:
 # Reference BGC status enum.
 class Status(Enum):
     MISSED = 0
-    PARTIALLY_COVERED = 1
-    COVERED = 2
-    COVERED_BY_FRAGMENTS = 3
+    FRAGMENTED_RECOVERY = 1
+    PARTIALLY_RECOVERED = 2
+    FULLY_RECOVERED = 3
 
 
 @dataclass
@@ -39,10 +40,16 @@ class ReferenceBgc(Bgc):
         status (Status): The status of the BGC.
         intersecting_assembly_bgcs (list[Intersection]): assembly BGCs that intersect
         with this BGC.
+        main_covering_assembly_bgc (Optional[Bgc]): The main covering assembly BGC for
+        this reference BGC.
+        recovered_product_types (list[str]): The recovered product types for this
+        reference BGC.
     """
 
     status: Status = Status.MISSED
     intersecting_assembly_bgcs: list[Intersection] = field(default_factory=list)
+    main_covering_assembly_bgc: Optional[Bgc] = None
+    recovered_product_types: list[str] = field(default_factory=list)
 
     @classmethod
     def from_bgc(cls, bgc: Bgc) -> "ReferenceBgc":

--- a/src/config.py
+++ b/src/config.py
@@ -1,10 +1,11 @@
 import time
-import yaml
-from dataclasses import dataclass
-from pathlib import Path
-from datetime import datetime
-from typing import Optional, Dict
 from argparse import Namespace as CommandLineArgs
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+import yaml
 
 
 @dataclass
@@ -13,13 +14,12 @@ class OutputConfig:
     symlink_to_latest: Path
     report: Path
 
-    def __init__(self,
-                 output_dir: Path):
+    def __init__(self, output_dir: Path):
         self.output_dir = output_dir
         # TODO: read these default values from config.yaml
-        self.symlink_to_latest = self.output_dir / Path('latest')
-        self.report = self.output_dir / Path('report.txt')
-        self.html_report = self.output_dir / Path('report.html')
+        self.symlink_to_latest = self.output_dir / Path("latest")
+        self.report = self.output_dir / Path("report.txt")
+        self.html_report = self.output_dir / Path("report.html")
 
 
 @dataclass
@@ -30,15 +30,21 @@ class ProductMappingConfig:
 @dataclass
 class Config:
     magic_number: int  # just a placeholder for future expansion of the config
-    magic_str: str     # just a placeholder for future expansion of the config
+    magic_str: str  # just a placeholder for future expansion of the config
     output_config: OutputConfig
     product_mapping_config: ProductMappingConfig
     bgc_completeness_margin: int
+    allowed_gap_for_fragmented_recovery: int
 
 
 def get_default_output_dir(cfg: dict) -> Path:
-    while (out_dir := (Path.cwd() / Path(cfg['default_output_dir_root']) /
-                       Path(datetime.now().strftime('%Y-%m-%d_%H-%M-%S')))).exists():
+    while (
+        out_dir := (
+            Path.cwd()
+            / Path(cfg["default_output_dir_root"])
+            / Path(datetime.now().strftime("%Y-%m-%d_%H-%M-%S"))
+        )
+    ).exists():
         time.sleep(1)
 
     return out_dir
@@ -46,15 +52,24 @@ def get_default_output_dir(cfg: dict) -> Path:
 
 def load_config(args: Optional[CommandLineArgs] = None) -> Config:
     tool_dir = Path(__file__).parent.parent.resolve()
-    configs_dir = tool_dir / Path('configs')
-    cfg = yaml.safe_load((configs_dir / 'config.yaml').open('r'))
-    out_dir = args.output_dir.resolve() \
-        if args is not None and args.output_dir is not None else get_default_output_dir(cfg)
+    configs_dir = tool_dir / Path("configs")
+    cfg = yaml.safe_load((configs_dir / "config.yaml").open("r"))
+    out_dir = (
+        args.output_dir.resolve()
+        if args is not None and args.output_dir is not None
+        else get_default_output_dir(cfg)
+    )
     product_mapping_config = ProductMappingConfig(
-        product_yamls={k: configs_dir / Path(v) for k, v in cfg['product_yamls'].items()}
+        product_yamls={
+            k: configs_dir / Path(v) for k, v in cfg["product_yamls"].items()
+        }
     )
 
-    return Config(magic_number=42, magic_str='',
-                  output_config=OutputConfig(out_dir),
-                  product_mapping_config=product_mapping_config,
-                  bgc_completeness_margin=cfg['bgc_completeness_margin'])
+    return Config(
+        magic_number=42,
+        magic_str="",
+        output_config=OutputConfig(out_dir),
+        product_mapping_config=product_mapping_config,
+        bgc_completeness_margin=cfg["bgc_completeness_margin"],
+        allowed_gap_for_fragmented_recovery=cfg["allowed_gap_for_fragmented_recovery"],
+    )

--- a/src/pipeline_helper.py
+++ b/src/pipeline_helper.py
@@ -163,6 +163,7 @@ class PipelineHelper:
         """
 
         analysis_report = ReportBuilder(ReportConfigManager()).build_report(
+            config=self.config,
             results=self.assembly_genome_mining_results,
             running_mode=self.running_mode,  # type: ignore
             quast_results=self.quast_results,

--- a/tests/test_pipeline_helper.py
+++ b/tests/test_pipeline_helper.py
@@ -185,6 +185,7 @@ def test_compute_stats_creates_analysis_report(pipeline_helper):
         pipeline_helper.compute_stats()
 
         mock_build_report.assert_called_once_with(
+            config=pipeline_helper.config,
             results=[mock_genome_mining_result],
             running_mode=RunningMode.COMPARE_TOOLS,
             quast_results=pipeline_helper.quast_results,


### PR DESCRIPTION
Add metrics:
"Fully recovered BGCs", "Partially recovered BGCs", "Missed BGCs", "Fragmented BGCs", "Misclassified product type", "Recovery rate".

Add allowed_gap_for_fragmented_recovery: 100 for disjoint BGCs calculation: BGCs considered non-intersecting if the gap between them is longer than 100 bp.

